### PR TITLE
Fix ProxyReqStreamReader read size

### DIFF
--- a/mtprotoproxy.py
+++ b/mtprotoproxy.py
@@ -864,13 +864,13 @@ class MTProtoSecureIntermediateFrameStreamWriter(LayeredStreamWriterBase):
 class ProxyReqStreamReader(LayeredStreamReaderBase):
     __slots__ = ()
 
-    async def read(self, msg):
+    async def read(self, n):
         RPC_PROXY_ANS = b"\x0d\xda\x03\x44"
         RPC_CLOSE_EXT = b"\xa2\x34\xb6\x5e"
         RPC_SIMPLE_ACK = b"\x9b\x40\xac\x3b"
         RPC_UNKNOWN = b'\xdf\xa2\x30\x57'
 
-        data = await self.upstream.read(1)
+        data = await self.upstream.read(n)
 
         if len(data) < 4:
             return b""


### PR DESCRIPTION
## Summary
- forward buffer size to upstream reader in ProxyReqStreamReader

## Testing
- `python3 -m py_compile mtprotoproxy.py pyaes/*.py`

------
https://chatgpt.com/codex/tasks/task_e_683fb89a67ac832b85804ba4fdb19d8e